### PR TITLE
HttpTransportProperties is not longer in Axis 2

### DIFF
--- a/src/org/nixos/disnix/client/DisnixInterface.java
+++ b/src/org/nixos/disnix/client/DisnixInterface.java
@@ -30,6 +30,7 @@ import org.apache.axis2.rpc.client.*;
 import org.apache.axis2.client.*;
 import org.apache.axis2.addressing.*;
 import org.apache.axis2.transport.http.*;
+import org.apache.axis2.transport.http.impl.httpclient4.*;
 
 /**
  * Provides a SOAP client interface to the Disnix Service.
@@ -72,7 +73,7 @@ public class DisnixInterface
 		if(System.getenv("DISNIX_SOAP_CLIENT_USERNAME") != null)
 		{
 			/* Authentication settings */
-			HttpTransportProperties.Authenticator auth = new HttpTransportProperties.Authenticator();
+			HttpTransportPropertiesImpl.Authenticator auth = new HttpTransportPropertiesImpl.Authenticator();
 			auth.setUsername(System.getenv("DISNIX_SOAP_CLIENT_USERNAME"));
 			auth.setPassword(System.getenv("DISNIX_SOAP_CLIENT_PASSWORD"));
 			options.setProperty(HTTPConstants.AUTHENTICATE, auth);


### PR DESCRIPTION
This should hopefully fix the following problem on nixpkgs build with newest axis 2.

```
    [javac] /build/DisnixWebService-0.8/build.xml:41: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 7 source files to /build/DisnixWebService-0.8/bin
    [javac] /build/DisnixWebService-0.8/src/org/nixos/disnix/client/DisnixInterface.java:75: error: cannot find symbol
    [javac]                     HttpTransportProperties.Authenticator auth = new HttpTransportProperties.Authenticator();
    [javac]                                            ^
    [javac]   symbol:   class Authenticator
    [javac]   location: class HttpTransportProperties
    [javac] /build/DisnixWebService-0.8/src/org/nixos/disnix/client/DisnixInterface.java:75: error: cannot find symbol
    [javac]                     HttpTransportProperties.Authenticator auth = new HttpTransportProperties.Authenticator();
    [javac]                                                                                             ^
    [javac]   symbol:   class Authenticator
    [javac]   location: class HttpTransportProperties
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.
    [javac] 2 errors```